### PR TITLE
Fixes for julia 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,24 @@ os:
 julia:
     - 0.7
     - 1.0
+    - 1.1
+    - 1.2
     - nightly
 notifications:
     email: false
-script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("SExpressions"); Pkg.test("SExpressions"; coverage=true)'
+
+# .travis.yml codecov support is broken; see https://github.com/invenia/PkgTemplates.jl/issues/68
+# codecov: true
 after_success:
-    - julia -e 'using Pkg; Pkg.add("Documenter")'
-    - julia -e 'using Pkg; cd(Pkg.dir("SExpressions")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-    - julia -e 'using Pkg; cd(Pkg.dir("SExpressions")); include(joinpath("docs", "make.jl"))'
+    - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+jobs:
+  include:
+    - stage: Documentation
+      julia: 1.1
+      script: julia --project=docs -e '
+          using Pkg;
+          Pkg.develop(PackageSpec(path=pwd()));
+          Pkg.instantiate();
+          include("docs/make.jl");'
+      after_success: skip
+

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,0 +1,83 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+deps = ["LibGit2", "Markdown", "Pkg", "Test"]
+git-tree-sha1 = "4d30e889c9f106a51ffa4791a88ffd4765bf20c3"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.7.0"
+
+[[Documenter]]
+deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Unicode"]
+git-tree-sha1 = "38509269fc99a9bc450fdb9e17e805021f3e5b1b"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.22.4"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "1f7a25b53ec67f5e9422f1f551ee216503f4a0fa"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.20.0"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,10 +2,9 @@ using Documenter
 using SExpressions
 
 makedocs(
-    format = :html,
+    format = Documenter.HTML(analytics="UA-68884109-1"),
     sitename = "SExpressions.jl",
     authors = "Fengyang Wang",
-    analytics = "UA-68884109-1",
     pages = [
         "index.md"
     ]

--- a/src/Parser/numeric.jl
+++ b/src/Parser/numeric.jl
@@ -63,7 +63,7 @@ context = Automa.CodeGenContext()
     curnumerator = true
     mark = 0
     $(Automa.generate_init_code(context, machine))
-    p_end = p_eof = endof(data)
+    p_end = p_eof = lastindex(data)
     gettoken() = data[mark:p-1]
 
     nextator!() = begin

--- a/src/Parser/util.jl
+++ b/src/Parser/util.jl
@@ -5,7 +5,7 @@ Return the number of bytes that would be read if `c` were read from `io`.
 """
 readsize(_::IO, x::Union{Base.BitInteger, Float16, Float32, Float64}) =
     sizeof(x)
-readsize(_::IO, c::Char) = Base.codelen(c)
+readsize(_::IO, c::Char) = @static VERSION < v"1.1.0" ? Base.codelen(c) : ncodeunits(c)
 
 """
     peek(io::IO, T::Type)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -95,10 +95,9 @@ end
 end
 
 @testset "macro" begin
-    # we try to limit these in number, because if they fail then a LoadError
-    # occurs, and that is bad for debugging
-    @test sx"1" == 1
-    @test sx"foo" == :foo
+    # Wrap in `@eval` to capture failures at test time rather than load time.
+    @test @eval(sx"1")   == 1
+    @test @eval(sx"foo") == :foo
 end
 
 end


### PR DESCRIPTION
* `Base.codelen()` has gone away in 1.1 and there's a public function for this.
* `endof()` went away in 1.0
* Minor test cleanup
* [edit] Also modernize the way that the package is tested in CI and documentation built